### PR TITLE
Set api service volume to api:/src

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - 8080
     volumes:
-      - api:/usr/src/app
+      - api:/src
     command: yarn start
     depends_on:
       mongodb:


### PR DESCRIPTION
Otherwise running okteto init will generate manifest with sync folder as `api:/usr/src/app` for api service which will not update file changes.