### PR TITLE
Revert 16 patch 1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         condition: service_healthy
 
   mongodb:
-    image: docker.io/bitnami/mongodb:5.0
+    image: docker.io/bitnami/mongodb:5.0.24
     environment:
       - MONGODB_USERNAME=okteto
       - MONGODB_PASSWORD=mongodb123

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         condition: service_healthy
 
   mongodb:
-    image: docker.io/bitnami/mongodb@sha256:a4dc5421b115090e3612b58d03fed11749d3a5f0a7e690755f73ddaa1dd8d4c8
+    image: docker.io/bitnami/mongodb:5.0
     environment:
       - MONGODB_USERNAME=okteto
       - MONGODB_PASSWORD=mongodb123


### PR DESCRIPTION
Reverts okteto/movies-with-compose#16

bitnami pushed a fix at:
- https://github.com/bitnami/containers/issues/62039#issuecomment-1952578242.

I tested in my cluster and it works fine.

The new sha is:

```
bitnami/mongodb@sha256:5145e297e491e543616e42df56b02a18783ca971f24cffe0d5a6717d25780afe
```

However, if we keep using `5.0` as tag it may hit cache and use the previous image.

That's why I changed it to `5.0.24` (latest patch available).

We could also stay with the current sha and close this PR.